### PR TITLE
fix: add file copy-assets to copy mail folder to dist after build

### DIFF
--- a/copy-assets.js
+++ b/copy-assets.js
@@ -1,0 +1,13 @@
+const fs = require('fs');
+const path = require('path');
+
+const srcDir = path.join(__dirname, 'src', 'mails');
+const destDir = path.join(__dirname, 'dist', 'src', 'mails');
+
+fs.mkdirSync(destDir, { recursive: true });
+
+fs.readdirSync(srcDir).forEach((file) => {
+    fs.copyFileSync(path.join(srcDir, file), path.join(destDir, file));
+});
+
+console.log('Copied mails to dist');

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
         "start": "node -r tsconfig-paths/register dist/src/server.js",
         "nodemon": "nodemon",
         "dev": "nodemon",
-        "build": "tsc",
+        "build": "tsc && node copy-assets.js",
         "debug": "ndb nodemon",
         "lint": "eslint \"{src,apps,libs,test}/**/*.ts\" --fix",
         "lint-staged": "lint-staged",


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced the build process to automatically copy asset files from the source to the distribution directory after compilation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->