### PR TITLE
fix: get all request by type

### DIFF
--- a/src/controllers/request.controller.ts
+++ b/src/controllers/request.controller.ts
@@ -112,6 +112,7 @@ export const getCourseApprovalRequestByCourseId = catchAsync(
 // Get all pending requests (optionally filtered by type)
 export const getAllPendingRequests = catchAsync(async (req: Request, res: Response, next: NextFunction) => {
     const { type } = req.query;
+    
     const filter: any = { 
         status: { $in: ['pending'] }, // Only show pending requests
         $or: [
@@ -121,11 +122,19 @@ export const getAllPendingRequests = catchAsync(async (req: Request, res: Respon
     };
     if (type) filter.type = type;
 
-    const requests = await RequestModel.find(filter).populate('courseId').populate('userId').populate('businessId');
+    const requests = await RequestModel.find(filter).lean();
+    
+    if (!requests.length) {
+        return next(new ErrorHandler('No pending requests found', 404));
+    }
 
-    if (!requests.length) return next(new ErrorHandler('No pending requests found', 404));
-
-    res.status(200).json({ success: true, data: requests });
+    res.status(200).json({ 
+        success: true, 
+        data: requests,
+        metadata: {
+            total: requests.length
+        }
+    });
 });
 
 // Handle request approval/rejection (generic)
@@ -413,6 +422,10 @@ export const getRequestStatistics = catchAsync(async (req: Request, res: Respons
         });
     }
 });
+
+
+
+
 
 // Create business approval request
 

--- a/src/interfaces/Request.ts
+++ b/src/interfaces/Request.ts
@@ -1,7 +1,7 @@
 import mongoose, { Document } from 'mongoose';
 
 export interface Request {
-    _id?: string;
+    _id?: mongoose.Types.ObjectId;
     courseId?: mongoose.Types.ObjectId | null;
     businessId?: mongoose.Types.ObjectId | null;
     userId: mongoose.Types.ObjectId;

--- a/src/routes/request.route.ts
+++ b/src/routes/request.route.ts
@@ -145,6 +145,28 @@ router.get(
 
 /**
  * @swagger
+ * /api/request/get-request-pending:
+ *   get:
+ *     summary: Get all pending requests (Admin only)
+ *     tags: [Request]
+ *     security:
+ *       - bearerAuth: []
+ *     parameters:
+ *       - in: query
+ *         name: type
+ *         schema:
+ *           type: string
+ *           enum: [course_approval, business_verification, instructor_verification]
+ *     responses:
+ *       200:
+ *         description: List of pending requests
+ *       404:
+ *         description: No pending requests found
+ */
+router.get('/get-request-pending', updateAccessToken, isAuthenticated, authorizeRoles('admin'), getAllPendingRequests);
+
+/**
+ * @swagger
  * /api/request/{requestId}:
  *   get:
  *     summary: Get a single request by ID (Admin only)
@@ -164,28 +186,6 @@ router.get(
  *         description: Request not found
  */
 router.get('/:requestId', updateAccessToken, isAuthenticated, authorizeRoles('admin'), getRequestById);
-
-/**
- * @swagger
- * /api/request/get-request-pending:
- *   get:
- *     summary: Get all pending requests (Admin only)
- *     tags: [Request]
- *     security:
- *       - bearerAuth: []
- *     parameters:
- *       - in: query
- *         name: type
- *         schema:
- *           type: string
- *           enum: [course_approval, business_verification, instructor_verification]
- *     responses:
- *       200:
- *         description: List of pending requests
- *       404:
- *         description: No pending requests found
- */
-router.get('/get-request-pending', isAuthenticated, authorizeRoles('admin'), getAllPendingRequests);
 
 /**
  * @swagger


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Added admin endpoint to list pending requests with optional type filter (course_approval, business_verification, instructor_verification).
  - Responses now include a metadata.total count alongside the data array.
  - Soft-deleted requests are excluded from results.

- Documentation
  - API documentation updated to reflect the new pending-requests listing endpoint, query parameters, and response schema.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->