### PR TITLE
fix: remove video url when unauth

### DIFF
--- a/src/controllers/course.controller.ts
+++ b/src/controllers/course.controller.ts
@@ -335,17 +335,21 @@ export const getSingleCourse = catchAsync(async (req: Request, res: Response, ne
     const totalCourses = instructorCourseIds.length;
 
     // === CHANGED: bỏ gating videoUrl theo isFree; giữ nguyên lesson publish ===
-    const processedSections = Array.isArray(course.sections)
-        ? course.sections.map((section: any) => ({
-              ...section,
-              lessons: Array.isArray(section.lessons)
-                  ? section.lessons.map((lesson: any) => ({
-                        ...lesson
-                        // KHÔNG còn: videoUrl: lesson.isFree ? lesson.videoUrl : undefined
-                    }))
-                  : []
-          }))
-        : [];
+   const processedSections = Array.isArray(course.sections)
+       ? course.sections.map((section: any) => ({
+             ...section,
+             lessons: Array.isArray(section.lessons)
+                 ? section.lessons.map((lesson: any) => {
+                       const { videoUrl, ...restLesson } = lesson;
+                       return {
+                           ...restLesson,
+                           videoUrl: undefined 
+                       };
+                   })
+                 : []
+         }))
+       : [];
+
 
     const totalLessons = processedSections.reduce(
         (sum, section) => sum + (Array.isArray(section.lessons) ? section.lessons.length : 0),


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed video URLs from lesson details in course pages, ensuring they are no longer exposed for any lessons (including previously free ones).
  * Maintains existing visibility rules for published sections and lessons without altering counts or structure.

* **Chores**
  * Standardized lesson data to consistently exclude video URLs while keeping all other course information unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->